### PR TITLE
https://github.com/grails/grails-core/issues/11367

### DIFF
--- a/micronaut/build.gradle
+++ b/micronaut/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     compile "org.hibernate:hibernate-core:5.4.0.Final"
     compile "org.grails.plugins:gsp"
     compileOnly "io.micronaut:micronaut-inject-groovy"
+    compile 'io.micronaut.configuration:micronaut-redis-lettuce:1.1.0'
     console "org.grails:grails-console"
     profile "org.grails.profiles:web"
     runtime "org.glassfish.web:el-impl:2.1.2-b03"
@@ -71,6 +72,7 @@ dependencies {
     testCompile "org.seleniumhq.selenium:selenium-support:3.14.0"
     testRuntime "org.seleniumhq.selenium:selenium-chrome-driver:3.14.0"
     testRuntime "org.seleniumhq.selenium:selenium-firefox-driver:3.14.0"
+    testCompile "com.github.kstyrc:embedded-redis:0.6"
 }
 
 bootRun {

--- a/micronaut/grails-app/conf/application.yml
+++ b/micronaut/grails-app/conf/application.yml
@@ -135,3 +135,5 @@ environments:
                 testOnReturn: false
                 jdbcInterceptors: ConnectionState
                 defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED
+redis:
+    enabled: true

--- a/micronaut/grails-app/services/micronaut/BeanInjectionService.groovy
+++ b/micronaut/grails-app/services/micronaut/BeanInjectionService.groovy
@@ -3,8 +3,8 @@ package micronaut
 import bean.injection.NamedService
 import bean.injection.Qualified
 import org.springframework.beans.factory.annotation.Autowired
-
-import javax.inject.Inject
+import io.lettuce.core.api.StatefulRedisConnection
+import org.springframework.beans.factory.annotation.Qualifier
 import javax.inject.Named
 
 class BeanInjectionService {
@@ -26,4 +26,9 @@ class BeanInjectionService {
 
     @Autowired
     NamedService namedService
+
+    // TODO: it should not be needed to add this Qualifier
+    @Qualifier("io.lettuce.core.api.StatefulRedisConnection(Primary)")
+    @Autowired
+    StatefulRedisConnection<String, String> statefulRedisConnection
 }

--- a/micronaut/src/integration-test/groovy/micronaut/BeanInjectionServiceSpec.groovy
+++ b/micronaut/src/integration-test/groovy/micronaut/BeanInjectionServiceSpec.groovy
@@ -3,9 +3,22 @@ package micronaut
 import grails.testing.mixin.integration.Integration
 import org.springframework.beans.factory.annotation.Autowired
 import spock.lang.Specification
+import redis.embedded.RedisServer
 
 @Integration
 class BeanInjectionServiceSpec extends Specification {
+
+    static RedisServer redisServer = new RedisServer(6379)
+
+    def setupSpec() {
+        redisServer.start()
+    }
+
+    def cleanupSpec() {
+        if(redisServer) {
+            redisServer.stop()
+        }
+    }
 
     @Autowired
     BeanInjectionService service
@@ -17,5 +30,6 @@ class BeanInjectionServiceSpec extends Specification {
         service.namedService3.name == "special"
         service.namedService4.name == "qualified"
         service.namedService.name == "primary"
+        service.statefulRedisConnection.sync().ping() == 'PONG'
     }
 }


### PR DESCRIPTION
Expanded integrationtest to demonstrate that it is not possible to inject StatefulRedisConnection without @Qualifier("io.lettuce.core.api.StatefulRedisConnection(Primary)")