### PR TITLE
Upgrade Gradle plugin for webdriver binaries

### DIFF
--- a/app1/build.gradle
+++ b/app1/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:$assetPipelineVersion"
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
+        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }
 
@@ -16,7 +16,7 @@ apply plugin: "war"
 apply plugin: "asset-pipeline"
 apply plugin: "org.grails.grails-web"
 apply plugin: "org.grails.grails-gsp"
-apply plugin:"com.energizedwork.webdriver-binaries"
+apply plugin: "com.github.erdi.webdriver-binaries"
 
 assets {
     minifyJs = true

--- a/app2/build.gradle
+++ b/app2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
+        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }
 
@@ -13,7 +13,7 @@ group "app2"
 
 apply plugin: "org.grails.grails-web"
 apply plugin: "org.grails.grails-gsp"
-apply plugin:"com.energizedwork.webdriver-binaries"
+apply plugin: "com.github.erdi.webdriver-binaries"
 
 dependencyManagement {
     imports {

--- a/app3/build.gradle
+++ b/app3/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
+        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }
 
@@ -13,7 +13,7 @@ group "app3"
 
 apply plugin: "org.grails.grails-web"
 apply plugin: "org.grails.grails-gsp"
-apply plugin:"com.energizedwork.webdriver-binaries"
+apply plugin: "com.github.erdi.webdriver-binaries"
 
 dependencyManagement {
     imports {

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
+        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }
 
@@ -13,7 +13,7 @@ group "datasources"
 
 apply plugin: "org.grails.grails-web"
 apply plugin: "org.grails.grails-gsp"
-apply plugin:"com.energizedwork.webdriver-binaries"
+apply plugin: "com.github.erdi.webdriver-binaries"
 
 dependencyManagement {
     imports {

--- a/gorm/build.gradle
+++ b/gorm/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
+        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }
 
@@ -13,7 +13,7 @@ group "gorm"
 
 apply plugin: "org.grails.grails-web"
 apply plugin: "org.grails.grails-gsp"
-apply plugin:"com.energizedwork.webdriver-binaries"
+apply plugin: "com.github.erdi.webdriver-binaries"
 
 dependencyManagement {
     imports {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 testingSupportVersion=3.1.0
 gebVersion=2.3.1
 seleniumVersion=3.141.59
-webdriverBinariesVersion=1.4
+webdriverBinariesVersion=2.7
 chromeDriverVersion=96.0.4664.45
 geckodriverVersion=0.24.0
 seleniumSafariDriverVersion=3.141.59

--- a/hyphenated/build.gradle
+++ b/hyphenated/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
+        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }
 
@@ -13,7 +13,7 @@ group "hyphenated"
 
 apply plugin: "org.grails.grails-web"
 apply plugin: "org.grails.grails-gsp"
-apply plugin:"com.energizedwork.webdriver-binaries"
+apply plugin: "com.github.erdi.webdriver-binaries"
 
 dependencyManagement {
     imports {

--- a/issue-11102/build.gradle
+++ b/issue-11102/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:$assetPipelineVersion"
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
+        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }
 
@@ -16,7 +16,7 @@ apply plugin: "war"
 apply plugin: "asset-pipeline"
 apply plugin: "org.grails.grails-web"
 apply plugin: "org.grails.grails-gsp"
-apply plugin:"com.energizedwork.webdriver-binaries"
+apply plugin: "com.github.erdi.webdriver-binaries"
 
 assets {
     minifyJs = true

--- a/issue-698-domain-save-npe/build.gradle
+++ b/issue-698-domain-save-npe/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
+        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }
 
@@ -13,7 +13,7 @@ group "grails301.domain.save.npe"
 
 apply plugin: "org.grails.grails-web"
 apply plugin: "org.grails.grails-gsp"
-apply plugin:"com.energizedwork.webdriver-binaries"
+apply plugin: "com.github.erdi.webdriver-binaries"
 
 dependencyManagement {
     imports {

--- a/micronaut/build.gradle
+++ b/micronaut/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
         classpath "org.grails.plugins:hibernate5:8.0.1"
-        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:2.0"
+        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:3.4.7"
     }
 }

--- a/namespaces/build.gradle
+++ b/namespaces/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
+        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }
 
@@ -13,7 +13,7 @@ group "namespaces"
 
 apply plugin: "org.grails.grails-web"
 apply plugin: "org.grails.grails-gsp"
-apply plugin:"com.energizedwork.webdriver-binaries"
+apply plugin: "com.github.erdi.webdriver-binaries"
 
 dependencyManagement {
     imports {


### PR DESCRIPTION
Obsolete Gradle plugin: `gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin` version 1.4
Was replaced by: `gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin` version 2.7

Fixes #186