### PR TITLE
Fix Java CI Status link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Functional tests for Grails Core
 
-[![Java CI](https://github.com/grails/grails-functional-tests/actions/workflows/gradle.yml/badge.svg)](https://github.com/grails/grails3-functional-tests/actions/workflows/gradle.yml)
+[![Java CI](https://github.com/grails/grails-functional-tests/actions/workflows/gradle.yml/badge.svg)](https://github.com/grails/grails-functional-tests/actions/workflows/gradle.yml)
 
 
 A Suite of functional tests for Grails


### PR DESCRIPTION
It currently links to an older archived repository.