### PR TITLE
fix(deps): Remove dependency on views-json-templates

### DIFF
--- a/issue-views-182/build.gradle
+++ b/issue-views-182/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     implementation "org.grails.plugins:hibernate5"
     implementation "org.hibernate:hibernate-core"
     implementation "org.grails.plugins:views-json:$viewsVersion"
-    implementation "org.grails.plugins:views-json-templates:$viewsVersion"
     console "org.grails:grails-console"
     profile "org.grails.profiles:rest-api"
     runtimeOnly "org.glassfish.web:el-impl:2.2"


### PR DESCRIPTION
The dependency `views-json-templates` is only intended for use in projects that use MongoDB.