### PR TITLE
allow dependency versions to be set by grails-bom so they automatically advance

### DIFF
--- a/app1/build.gradle
+++ b/app1/build.gradle
@@ -44,14 +44,14 @@ dependencies {
     implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
-    implementation "org.grails.plugins:scaffolding:$scaffoldingVersion"
+    implementation "org.grails.plugins:scaffolding"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"
-    runtimeOnly "org.grails.plugins:fields:$fieldsVersion"
+    runtimeOnly "org.grails.plugins:fields"
     runtimeOnly "org.apache.tomcat:tomcat-jdbc"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     console "org.grails:grails-console"
     testImplementation "io.micronaut:micronaut-http-client:$micronautVersion"

--- a/app1/build.gradle
+++ b/app1/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     implementation "org.grails:grails-core"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
     implementation "org.grails.plugins:scaffolding"

--- a/app1/build.gradle
+++ b/app1/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     implementation "org.grails:grails-core"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
     implementation "org.grails.plugins:scaffolding"
 

--- a/app2/build.gradle
+++ b/app2/build.gradle
@@ -36,11 +36,11 @@ dependencies {
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"
-    runtimeOnly "org.grails.plugins:scaffolding:$scaffoldingVersion"
-    runtimeOnly "org.grails.plugins:fields:$fieldsVersion"
+    runtimeOnly "org.grails.plugins:scaffolding"
+    runtimeOnly "org.grails.plugins:fields"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     console "org.grails:grails-console"
 }

--- a/app2/build.gradle
+++ b/app2/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 

--- a/app2/build.gradle
+++ b/app2/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"

--- a/app3/build.gradle
+++ b/app3/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 

--- a/app3/build.gradle
+++ b/app3/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "org.grails.plugins:scaffolding"

--- a/app3/build.gradle
+++ b/app3/build.gradle
@@ -35,11 +35,11 @@ dependencies {
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 
-    runtimeOnly "org.grails.plugins:scaffolding:$scaffoldingVersion"
-    runtimeOnly "org.grails.plugins:fields:$fieldsVersion"
+    runtimeOnly "org.grails.plugins:scaffolding"
+    runtimeOnly "org.grails.plugins:fields"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     console "org.grails:grails-console"
 }

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -36,12 +36,12 @@ dependencies {
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"
-    runtimeOnly "org.grails.plugins:scaffolding:$scaffoldingVersion"
-    runtimeOnly "org.grails.plugins:fields:$fieldsVersion"
+    runtimeOnly "org.grails.plugins:scaffolding"
+    runtimeOnly "org.grails.plugins:fields"
     runtimeOnly "org.apache.tomcat:tomcat-jdbc"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     console "org.grails:grails-console"
 }

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"

--- a/gorm/build.gradle
+++ b/gorm/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"

--- a/gorm/build.gradle
+++ b/gorm/build.gradle
@@ -37,12 +37,12 @@ dependencies {
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"
-    runtimeOnly "org.grails.plugins:scaffolding:$scaffoldingVersion"
-    runtimeOnly "org.grails.plugins:fields:$fieldsVersion"
+    runtimeOnly "org.grails.plugins:scaffolding"
+    runtimeOnly "org.grails.plugins:fields"
     runtimeOnly "org.apache.tomcat:tomcat-jdbc"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     console "org.grails:grails-console"
 }

--- a/gorm/build.gradle
+++ b/gorm/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,12 @@ grailsGradlePluginVersion=7.0.0-SNAPSHOT
 grailsSitemesh3Version=7.0.0-SNAPSHOT
 # used by grails-gradle-plugin to force the groovy version
 groovyVersion=4.0.23
-hibernate5Version=5.6.15.Final
 jakartaXmlBindVersion=4.0.2
+
 # no longer comes from grails-bom
 micronautVersion=4.6.5
 micronautSerdeJacksonVersion=2.11.0
+
 seleniumVersion=4.25.0
 servletApiVersion=6.0.0
 springSecurityCoreVersion=7.0.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,20 @@
 assetPipelineVersion=5.0.1
-fieldsVersion=6.0.0-SNAPSHOT
 gebVersion=7.0
-gormVersion=9.0.0-SNAPSHOT
 # used to pull latest -SNAPSHOT version
 grailsCoreBranch=7.0.x
 grailsGradlePluginVersion=7.0.0-SNAPSHOT
 grailsSitemesh3Version=7.0.0-SNAPSHOT
+# used by grails-gradle-plugin to force the groovy version
 groovyVersion=4.0.23
 hibernate5Version=5.6.15.Final
 jakartaXmlBindVersion=4.0.2
+# no longer comes from grails-bom
 micronautVersion=4.6.5
 micronautSerdeJacksonVersion=2.11.0
-scaffoldingVersion=6.0.0-SNAPSHOT
 seleniumVersion=4.25.0
 servletApiVersion=6.0.0
 springSecurityCoreVersion=7.0.0-SNAPSHOT
-testingSupportVersion=4.0.0-SNAPSHOT
+# required for org.grails.plugins:views-gradle version
 viewsVersion=4.0.0-SNAPSHOT
 
 webdriverBinariesVersion=3.2

--- a/hyphenated/build.gradle
+++ b/hyphenated/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 

--- a/hyphenated/build.gradle
+++ b/hyphenated/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "org.grails.plugins:scaffolding"

--- a/hyphenated/build.gradle
+++ b/hyphenated/build.gradle
@@ -35,14 +35,14 @@ dependencies {
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 
-    runtimeOnly "org.grails.plugins:scaffolding:$scaffoldingVersion"
-    runtimeOnly "org.grails.plugins:fields:$fieldsVersion"
+    runtimeOnly "org.grails.plugins:scaffolding"
+    runtimeOnly "org.grails.plugins:fields"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"
     runtimeOnly "org.apache.tomcat:tomcat-jdbc"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     console "org.grails:grails-console"
 }

--- a/issue-11102/build.gradle
+++ b/issue-11102/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     runtimeOnly "org.apache.tomcat:tomcat-jdbc"
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     testImplementation "io.micronaut:micronaut-http-client:$micronautVersion"
     testImplementation "io.micronaut.serde:micronaut-serde-jackson:$micronautSerdeJacksonVersion"

--- a/issue-698-domain-save-npe/build.gradle
+++ b/issue-698-domain-save-npe/build.gradle
@@ -36,12 +36,12 @@ dependencies {
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"
-    runtimeOnly "org.grails.plugins:scaffolding:$scaffoldingVersion"
-    runtimeOnly "org.grails.plugins:fields:$fieldsVersion"
+    runtimeOnly "org.grails.plugins:scaffolding"
+    runtimeOnly "org.grails.plugins:fields"
     runtimeOnly "org.apache.tomcat:tomcat-jdbc"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     console "org.grails:grails-console"
 }

--- a/issue-698-domain-save-npe/build.gradle
+++ b/issue-698-domain-save-npe/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 

--- a/issue-698-domain-save-npe/build.gradle
+++ b/issue-698-domain-save-npe/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"

--- a/issue-views-182/build.gradle
+++ b/issue-views-182/build.gradle
@@ -41,14 +41,14 @@ dependencies {
     implementation "org.grails.plugins:events"
     implementation "org.grails.plugins:hibernate5"
     implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
-    implementation "org.grails.plugins:views-json:$viewsVersion"
+    implementation "org.grails.plugins:views-json"
     console "org.grails:grails-console"
     profile "org.grails.profiles:rest-api"
     runtimeOnly "com.h2database:h2"
     runtimeOnly "org.apache.tomcat:tomcat-jdbc"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     testImplementation "io.micronaut:micronaut-http-client:$micronautVersion"
     testImplementation "io.micronaut.serde:micronaut-serde-jackson:$micronautSerdeJacksonVersion"

--- a/issue-views-182/build.gradle
+++ b/issue-views-182/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation "org.grails.plugins:async"
     implementation "org.grails.plugins:events"
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.grails.plugins:views-json"
     console "org.grails:grails-console"
     profile "org.grails.profiles:rest-api"

--- a/micronaut/build.gradle
+++ b/micronaut/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "org.grails.plugins:hibernate5:$gormVersion"
+        classpath "org.grails.plugins:hibernate5"
         classpath "com.github.erdi:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:$assetPipelineVersion"
     }

--- a/micronaut/build.gradle
+++ b/micronaut/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     implementation "org.grails.plugins:scaffolding"
     implementation "org.grails.plugins:events"
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.grails.plugins:gsp"
     compileOnly "io.micronaut:micronaut-inject-groovy"
     console "org.grails:grails-console"

--- a/namespaces/build.gradle
+++ b/namespaces/build.gradle
@@ -36,12 +36,12 @@ dependencies {
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"
-    runtimeOnly "org.grails.plugins:scaffolding:$scaffoldingVersion"
-    runtimeOnly "org.grails.plugins:fields:$fieldsVersion"
+    runtimeOnly "org.grails.plugins:scaffolding"
+    runtimeOnly "org.grails.plugins:fields"
     runtimeOnly "org.apache.tomcat:tomcat-jdbc"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     console "org.grails:grails-console"
 }

--- a/namespaces/build.gradle
+++ b/namespaces/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core-jakarta:$hibernate5Version"
     implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 

--- a/namespaces/build.gradle
+++ b/namespaces/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-ehcache:$hibernate5Version"
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"

--- a/plugins/issue11005/build.gradle
+++ b/plugins/issue11005/build.gradle
@@ -32,8 +32,8 @@ dependencies {
     api "org.grails:grails-dependencies"
     api "jakarta.servlet:jakarta.servlet-api:$servletApiVersion"
 
-    testImplementation "org.grails:grails-web-testing-support:$testingSupportVersion"
-    testImplementation "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation "org.grails:grails-gorm-testing-support"
 
     console "org.grails:grails-console"
 }


### PR DESCRIPTION
grails-functional-tests pulls the latest `-SNAPSHOT` version from the `grails-core` branch (grailsCoreBranch)

these changes allow several dependencies' versions to be set by the `grails-bom` based on that snapshots instead of requiring manual updates in `gradle.properties`.

org.grails.plugins:hibernate5 sets the hibernate-core-jakarta and hibernate-ehcache versions.