### PR TITLE
github workflow: use liberica and run on java 17, 21 and 23

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17']
+        java: ['17', '21', '23']
     env:
       RUN_TESTS_ONLY: false
     steps:
@@ -31,7 +31,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'liberica'
           java-version: ${{ matrix.java }}
       - name: Run Build
         id: build

--- a/build.gradle
+++ b/build.gradle
@@ -42,10 +42,8 @@ subprojects {
     }
     apply plugin: 'java'
 
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(17)
-        }
+    compileJava {
+        options.release = 17
     }
 
     dependencies {


### PR DESCRIPTION
I was originally going to add `--refresh-dependencies`, but do not want to risk https://github.com/grails/grails-testing-support/issues/443 occurring on the github workflows until we have a fix.

This PR uses Gradle Release Flag instead of Java Toolchain so the github workflow can control the version of Java.  `sourceCompatibility `is deprecated and marked for removal in Gradle 9.  https://docs.gradle.org/current/userguide/building_java_projects.html#sec:compiling_with_release

```
    compileJava {
        options.release = 17
    }
```