### PR TITLE
remove oss snapshot repo, was only used for sitemesh3 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ subprojects {
     repositories {
         maven { url "https://repo.grails.org/grails/core" }
         mavenCentral()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 
     tasks.withType(Test) {


### PR DESCRIPTION
which is proxied by repo.grails.org now

https://repo.grails.org/ui/native/core/org/sitemesh/grails-plugin-sitemesh3/7.0.0-SNAPSHOT/