### PR TITLE
Remove `@PendingFeature` From Tests That Are Now Working Again

### DIFF
--- a/namespaces/src/integration-test/groovy/context/ContextPathSpec.groovy
+++ b/namespaces/src/integration-test/groovy/context/ContextPathSpec.groovy
@@ -11,7 +11,6 @@ import spock.lang.PendingFeature
 @Rollback
 class ContextPathSpec extends ContainerGebSpec {
 
-    @PendingFeature(reason = 'title is blank')
     void "test the context path defined in the environment overrides the standard one"() {
         when:
         go '/myAppTest'

--- a/namespaces/src/integration-test/groovy/namespaces/PageControllerSpec.groovy
+++ b/namespaces/src/integration-test/groovy/namespaces/PageControllerSpec.groovy
@@ -8,7 +8,6 @@ import spock.lang.PendingFeature
 @Integration
 class PageControllerSpec extends ContainerGebSpec {
 
-    @PendingFeature(reason = 'title is blank')
     void "test that the page renders correctly"() {
         when: "The admin page is visited"
         go '/myAppTest/admin/page/index'

--- a/namespaces/src/integration-test/groovy/namespaces/admin/ReportControllerSpec.groovy
+++ b/namespaces/src/integration-test/groovy/namespaces/admin/ReportControllerSpec.groovy
@@ -8,7 +8,6 @@ import spock.lang.PendingFeature
 @Integration
 class ReportControllerSpec extends ContainerGebSpec {
 
-    @PendingFeature(reason = 'title is blank')
     void "test that admin report page renders correctly"() {
         when: "The admin report page is visited"
         go '/myAppTest/admin/report/index'


### PR DESCRIPTION
Thanks to https://github.com/codeconsole/grails-plugin-sitemesh3/commit/84a0e32622cddef7e98ddc6aaeae557bf3a4af71, `ContextPathSpec`, `PageControllerSpec` and `ReportControllerSpec` are now working again.