### PR TITLE
Remove `@PendingFeature` from tests that are now working

### DIFF
--- a/app1/src/integration-test/groovy/functionaltests/InterceptorFunctionalSpec.groovy
+++ b/app1/src/integration-test/groovy/functionaltests/InterceptorFunctionalSpec.groovy
@@ -44,7 +44,6 @@ class InterceptorFunctionalSpec extends ContainerGebSpec {
         $().text() == 'Name: JSB'
     }    
 
-    @PendingFeature(reason = 'text == Page Not Found')
     void 'Test that after interceptor can render text'() {
         when:
         go '/demo/show?interceptorRendersText=true'

--- a/app1/src/integration-test/groovy/functionaltests/UploadControllerSpec.groovy
+++ b/app1/src/integration-test/groovy/functionaltests/UploadControllerSpec.groovy
@@ -1,17 +1,14 @@
 package functionaltests
 
-
 import grails.plugin.geb.ContainerGebSpec
 import grails.testing.mixin.integration.Integration
 import org.testcontainers.images.builder.Transferable
-import spock.lang.PendingFeature
 
 /**
  */
 @Integration(applicationClass = Application)
 class UploadControllerSpec extends ContainerGebSpec {
 
-    @PendingFeature(reason='https://github.com/grails/grails-core/issues/13849')
     void "Test file upload"() {
         when:"When go to an upload page"
         go "/upload/index"
@@ -26,7 +23,6 @@ class UploadControllerSpec extends ContainerGebSpec {
         $('p').text() == 'Test upload'
     }
 
-    @PendingFeature(reason='https://github.com/grails/grails-core/issues/13849')
     void "Test file upload parameters"() {
         when:"When go to an upload page"
         go "/upload/index"


### PR DESCRIPTION
Thanks to grails/grails-core#13908, 3 more tests can be re-enabled.