### PR TITLE
Update to asset-pipeline 5.0.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-assetPipelineVersion=5.0.1
+assetPipelineVersion=5.0.3
 # used to pull latest -SNAPSHOT version
 grailsCoreBranch=7.0.x
 grailsGradlePluginVersion=7.0.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-assetPipelineVersion=5.0.3
+assetPipelineVersion=5.0.4
 # used to pull latest -SNAPSHOT version
 grailsCoreBranch=7.0.x
 grailsGradlePluginVersion=7.0.0-SNAPSHOT


### PR DESCRIPTION
Failures caused by:

https://github.com/grails/grails-functional-tests/actions/runs/12302112195

Related to https://github.com/grails/grails-core/pull/13920/files

5.0.4 should resolve.